### PR TITLE
chore: prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This changelog records verifiable changes represented in the repository history.
 
 ## [Unreleased]
 
+No entries yet.
+
+## [0.3.1] - 2026-09-02
+
+### Added
+
+- Added a security policy, contribution guide, structured issue forms, and a pull request checklist (`bb233a2`).
+- Added fact-based release notes and README navigation for the new maintenance resources.
+
 ### Fixed
 
 - Stabilized committed CSS bundles across Windows and Linux by replacing platform-sensitive path hashes with a plugin-scoped namespace (`4943e02`).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome"></a>
   <a href="https://awesome-dsh-plugin.com"><img src="https://awesome-dsh-plugin.com/badge.svg" alt="Awesome DSH Plugin"></a>
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DeepSeek_Harness-plugin-2f6cff.svg" alt="DeepSeek Harness plugin"></a>
-  <img src="https://img.shields.io/badge/version-0.3.0-2f6cff.svg" alt="Version 0.3.0">
+  <img src="https://img.shields.io/badge/version-0.3.1-2f6cff.svg" alt="Version 0.3.1">
   <img src="https://img.shields.io/badge/data-local--first-6f42c1.svg" alt="Local-first data">
   <img src="https://img.shields.io/badge/AI_analysis-opt--in-f59e0b.svg" alt="Opt-in AI analysis">
   <img src="https://img.shields.io/badge/privacy-allowlist-0f9d8a.svg" alt="Allowlist privacy">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-token-usage",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Persistent token usage records and dashboard for DeepSeek Harness",
   "keywords": [


### PR DESCRIPTION
## Summary

- bump the source-plugin package version and README badge from 0.3.0 to 0.3.1
- move the cross-platform bundle fix from Unreleased into the 0.3.1 release notes
- record the community maintenance foundation merged in PR #3

## Verification

- package, README badge, and changelog version metadata agree on `0.3.1`
- `npm pack --dry-run --json` reports `dsh-token-usage@0.3.1` with the unchanged 41-file allowlisted payload
- `git diff --check` passed
- base `main` was clean and identical across local HEAD, `origin/main`, and `git ls-remote` before the release branch was created

After this PR and the post-merge `main` CI pass, the release tag and GitHub Release will be created from the exact verified main commit.